### PR TITLE
Peer delete did not trigger ZEBRA_NEXTHOP_UNREGISTER to ZEBRA results…

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -88,7 +88,7 @@ int bgp_find_nexthop(struct bgp_info *path, int connected)
 
 static void bgp_unlink_nexthop_check(struct bgp_nexthop_cache *bnc)
 {
-	if (LIST_EMPTY(&(bnc->paths)) && bnc->nht_info) {
+	if (LIST_EMPTY(&(bnc->paths)) && !bnc->nht_info) {
 		if (BGP_DEBUG(nht, NHT)) {
 			char buf[PREFIX2STR_BUFFER];
 			zlog_debug("bgp_unlink_nexthop: freeing bnc %s",


### PR DESCRIPTION
… in leak of route node objects in zebra

  RCA :

  bgp_nexthop_cache is allocated and ZEBRA_NEXTHOP_REGISTER is sent to ZEBRA.

  The association of BGP is as below :
  (nexthop_cache_table)<---->bgp_nexthop_cache---->peer
                                  |<--------------> bgp_info

  for peer association bnc has nht_info
  for bgp_info bnc has list count

  Allocation of bnc :
  Scenario 1: When peer pointer exists
  Scenario 2: When peer pointer does not exists and bgp_info exists via bgp_update in IBGP session, when next-hop is
              not self.

  Allocation is fine in all scenarios

  Deletion of bnc:
  Scenario 1: When peer pointer exists
  Scenario 2: When peer pointer does not exists

  The deletion is triggered via bgp_unlink_nexthop_by_peer()
  In this context bgp->nht_info sets to NULL, which is correct as peer is going to delete.
  but in bgp_unlink_nexthop_check() expects the nht_info should not be NULL.
  So it will not call bgp_unlink_nexthop_check to ZEBRA

  Fix :

  When bgp_unlink_nexthop_check() gets called;
  In both the above scenarios the PEER should be NULL and bgp_info list count should be zero.

  Also there was one issue : 2198

  The code checked-in in this context was added to avoid the crash, but it seems the crash was coming due to some other problem.

  I have tried topotest multiple times but did not face any crash. So I am reverting this change.

  If still it crashes then i will check that.

  Signed-off-by: vishaldhingra vdhingra@vmware.com